### PR TITLE
adjusting pricing and premier PR commitment

### DIFF
--- a/membership/consultants.html
+++ b/membership/consultants.html
@@ -204,55 +204,52 @@ description: The consultant tier of membership is for those who provide services
       <!--body-->
       <div class="relative p-6 flex-auto">
         
-          <table class="table-auto"> 
-            <thead>
-              <th>Size</th>
-              <th>Finops Fdn Fees</th>
-              <th>Linux Fdn Fees</th>
-              <th>Combined Fees</th>
-            </thead>
-            <tbody>
-              <tr>
-                <td>5000+</td>
-                <td>$70,000</td>
-                <td>$20,000</td>
-                <td>$90,000</td>
-              </tr>
-              <tr>
-                <td>2000-4999</td>
-                <td>$35,000</td>
-                <td>$15,000</td>
-                <td>$50,000</td>
-              </tr>
-              <tr>
-                <td>500-1999</td>
-                <td>$25,000</td>
-                <td>$15,000</td>
-                <td>$40,000</td>
-              </tr>
-              <tr>
-                <td>100-499</td>
-                <td>$10,000</td>
-                <td>$10,000</td>
-                <td>$20,000</td>
-              </tr>
-              <tr>
-                <td>10-99</td>
-                <td>$5,000</td>
-                <td>$5,000</td>
-                <td>$10,000</td>
-              </tr>
-              <tr>
-                <td>0-10</td>
-                <td>$2,500</td>
-                <td>$5,000</td>
-                <td>$7,500</td>
-              </tr>
-            </tbody>
-          </table>
-          <p class="my-4 text-blueGray-500 text-base leading-relaxed">
-            Pricing determined by size or organization and existing membership of the Linux Foundation. Please submit a request for more details.
-          </p>
+        <table class="table-auto text-sm text-center"> 
+          <thead>
+            <th>Size</th>
+            <th>New to Linux Fdn<sup>*</sup></th>
+            <th>Existing Linux Fdn Member<sup>**</sup></th>
+            <th>FOCPCerts Req<sup>***</sup></th>
+          </thead>
+          <tbody>
+            <tr>
+              <td>10000+</td>
+              <td>$90,000</td>
+              <td>$70,000</td>
+              <td>75</td>
+            </tr>
+            <tr>
+              <td>5000-9999</td>
+              <td>$70,000</td>
+              <td>$50,000</td>
+              <td>50</td>
+            </tr>
+            <tr>
+              <td>500-4999</td>
+              <td>$45,000</td>
+              <td>$30,000</td>
+              <td>35</td>
+            </tr>
+            <tr>
+              <td>100-499</td>
+              <td>$25,000</td>
+              <td>$15,000</td>
+              <td>10</td>
+            </tr>
+            <tr>
+              <td>0-99</td>
+              <td>$10,000</td>
+              <td>$5,000</td>
+              <td>3</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="my-4 text-blueGray-500 text-sm leading-relaxed">
+          Pricing determined by size or organization and existing membership of the Linux Foundation. Please submit a request for more details.
+        </p>
+        <p><small>* Linux Foundation membership (Silver minimum) is required to join the FinOps Foundation.</small></p>
+        <p><small>** Existing LF members simply need to add a FinOps Participation Agreement to their existing LF membership</small></p>
+        <p><small>*** FCSP, FCP, FTP require minimum FinOps Certified Practitioner certification levels, additional costs will apply</small></p>
       </div>
       <!--footer-->
       <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
@@ -290,7 +287,7 @@ description: The consultant tier of membership is for those who provide services
           <li>Enjoy most prominent placement in displays of membership including on the website and in marketing materials</li>
           <li>Increased access to F2 invitation-only member events</li>
           <li>Receive ongoing, individual engagement from F2 Board and Staff</li>
-          <li>Individualized press campaign upon membership announcement with the LF PR team</li>
+          <li>Included in the press campaign with the Linux Foundation PR team</li>
         </ul>
         <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
           Pricing $125k/yr, minimum two years (includes board and TAC seats)

--- a/membership/vendor.html
+++ b/membership/vendor.html
@@ -167,55 +167,52 @@ description: Technology vendor membership is for those who provide platforms or 
       <!--body-->
       <div class="relative p-6 flex-auto">
         
-          <table class="table-auto"> 
+          <table class="table-auto text-sm text-center"> 
             <thead>
               <th>Size</th>
-              <th>Finops Fdn Fees</th>
-              <th>Linux Fdn Fees</th>
-              <th>Combined Fees</th>
+              <th>New to Linux Fdn<sup>*</sup></th>
+              <th>Existing Linux Fdn Member<sup>**</sup></th>
+              <th>FOCPCerts Req<sup>***</sup></th>
             </thead>
             <tbody>
               <tr>
-                <td>5000+</td>
-                <td>$70,000</td>
-                <td>$20,000</td>
+                <td>10000+</td>
                 <td>$90,000</td>
+                <td>$70,000</td>
+                <td>75</td>
               </tr>
               <tr>
-                <td>2000-4999</td>
-                <td>$35,000</td>
-                <td>$15,000</td>
+                <td>5000-9999</td>
+                <td>$70,000</td>
                 <td>$50,000</td>
+                <td>50</td>
               </tr>
               <tr>
-                <td>500-1999</td>
-                <td>$25,000</td>
-                <td>$15,000</td>
-                <td>$40,000</td>
+                <td>500-4999</td>
+                <td>$45,000</td>
+                <td>$30,000</td>
+                <td>35</td>
               </tr>
               <tr>
                 <td>100-499</td>
-                <td>$10,000</td>
-                <td>$10,000</td>
-                <td>$20,000</td>
+                <td>$25,000</td>
+                <td>$15,000</td>
+                <td>10</td>
               </tr>
               <tr>
-                <td>10-99</td>
-                <td>$5,000</td>
-                <td>$5,000</td>
+                <td>0-99</td>
                 <td>$10,000</td>
-              </tr>
-              <tr>
-                <td>0-10</td>
-                <td>$2,500</td>
                 <td>$5,000</td>
-                <td>$7,500</td>
+                <td>3</td>
               </tr>
             </tbody>
           </table>
-          <p class="my-4 text-blueGray-500 text-base leading-relaxed">
+          <p class="my-4 text-blueGray-500 text-sm leading-relaxed">
             Pricing determined by size or organization and existing membership of the Linux Foundation. Please submit a request for more details.
           </p>
+          <p><small>* Linux Foundation membership (Silver minimum) is required to join the FinOps Foundation.</small></p>
+          <p><small>** Existing LF members simply need to add a FinOps Participation Agreement to their existing LF membership</small></p>
+          <p><small>*** FCSP, FCP, FTP require minimum FinOps Certified Practitioner certification levels, additional costs will apply</small></p>
       </div>
       <!--footer-->
       <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
@@ -253,7 +250,7 @@ description: Technology vendor membership is for those who provide platforms or 
           <li>Enjoy most prominent placement in displays of membership including on the website and in marketing materials</li>
           <li>Increased access to F2 invitation-only member events</li>
           <li>Receive ongoing, individual engagement from F2 Board and Staff</li>
-          <li>Individualized press campaign upon membership announcement with the LF PR team</li>
+          <li>Included in the press campaign with the Linux Foundation PR team</li>
         </ul>
         <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
           Pricing $125k/yr, minimum two years (includes board and TAC seats)


### PR DESCRIPTION
- Adjusted pricing matrix to match the vendor deck
- Adjusted wording for premier members to not specify 'individual' press coverage to a broader terminology: 'Included in the press campaign with the Linux Foundation PR team' 