### PR TITLE
Global update of "committment" to "commitment".

### DIFF
--- a/_vendor-members/apptio.md
+++ b/_vendor-members/apptio.md
@@ -56,7 +56,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/cloudsoft.md
+++ b/_vendor-members/cloudsoft.md
@@ -52,7 +52,7 @@ supported-functions:
 - Data Processing
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Containers Capabilities

--- a/_vendor-members/contino.md
+++ b/_vendor-members/contino.md
@@ -65,7 +65,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/costimize.md
+++ b/_vendor-members/costimize.md
@@ -57,7 +57,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Policy Management
 - Trending & Variance Analysis
 - Containers Capabilities

--- a/_vendor-members/doit-international.md
+++ b/_vendor-members/doit-international.md
@@ -63,7 +63,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/hcl-technologies.md
+++ b/_vendor-members/hcl-technologies.md
@@ -73,7 +73,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/kubecost.md
+++ b/_vendor-members/kubecost.md
@@ -51,7 +51,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/sada.md
+++ b/_vendor-members/sada.md
@@ -56,7 +56,7 @@ supported-functions:
 - Learning
 - Autoscaling
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/softwareone.md
+++ b/_vendor-members/softwareone.md
@@ -53,7 +53,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/_vendor-members/virtasant.md
+++ b/_vendor-members/virtasant.md
@@ -62,7 +62,7 @@ supported-functions:
 - Data Processing
 - Data Visualization
 - Data Analytics
-- Committment Tracking
+- Commitment Tracking
 - Trending & Variance Analysis
 
 # Edit as appropriate to display supported clouds

--- a/_vendor-members/vmware.md
+++ b/_vendor-members/vmware.md
@@ -53,7 +53,7 @@ supported-functions:
 - Data Visualization
 - Data Analytics
 - Budget Alerting
-- Committment Tracking
+- Commitment Tracking
 - Marketplace
 - Policy Management
 - Trending & Variance Analysis

--- a/framework/functions.md
+++ b/framework/functions.md
@@ -27,7 +27,7 @@ layout: default
 - [Data Visualization](data-visualization)
 - [Data Analytics](data-analytics)
 - [Budget Alerting](budget-alerting)
-- [Committment Tracking](committment-tracking)
+- [Commitment Tracking](commitment-tracking)
 - [Marketplace](marketplace)
 - [Policy Management](policy-management)
 - [Trending & Variance Analysis](trending-and-variance-analysis)


### PR DESCRIPTION
This PR completely fixes #95 (at a minimum, the "URL, slug, and title has typo in "commitment" part). Currently, the URL (https://www.finops.org/framework/functions/commitment-tracking/) has the correct spelling and loads correctly. But the Functions page (https://www.finops.org/framework/functions/) still references the incorrect spelling, which results in a broken link (https://www.finops.org/framework/functions/committment-tracking) live on the website.

While fixing this, I also globally searched and replaced other uses of "committment" with "commitment", which updated some vendor descriptions.