### PR TITLE
Tagging & Labeling - GCP Link Revision

### DIFF
--- a/framework/functions/tagging-labeling.md
+++ b/framework/functions/tagging-labeling.md
@@ -62,13 +62,13 @@ These links are provided as potentially relevant industry resources. The FinOps 
 ### Cloud Specific Best Practices
 
 - [AWS](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
-- [GCP](https://cloud.google.com/compute/docs/labeling-resources)
+- [GCP](https://cloud.google.com/resource-manager/docs/creating-managing-labels)
 - [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/tag-portal)
 
 ### Cloud Native Tooling
 
 - [AWS Organizations](https://aws.amazon.com/organizations/)
-- [GCP Data Labeling](https://console.cloud.google.com/data-labeling)
+- [GCP Resource Manager](https://cloud.google.com/resource-manager)
 
 ### Relevant FinOps Certified Platforms
 


### PR DESCRIPTION
Proposing link revisions for Google Cloud on this page.

1. The "Cloud Specific Best Practices" link goes to a labeling page that's specific to Compute Engine. There's a labeling page under the Resource Manager documentation, which is more global in nature. Updated to this one.
2. The "Cloud Native Tooling" link goes to a Cloud Console page for a service that uses human labeling of input data for ML model training. This isn't relevant to the subject matter. Updated with a link to the Resource Manager, which would be the equivalent of the AWS organization.