### PR TITLE
update multi-cloud WG project page

### DIFF
--- a/projects/multi-cloud-tools-and-terminology.md
+++ b/projects/multi-cloud-tools-and-terminology.md
@@ -35,30 +35,30 @@ Each Cloud Service Provider has different tools available to help FinOps practit
 
 |  | GCP        | AWS           | Azure  |
 | ------------- | ------------- | ------------- | ------------- |
-| Cloud Cost Planning | GCP Pricing Calculator | GCP Pricing Calculator | Azure Pricing Calculator |
+| *Cloud Cost Planning* | GCP Pricing Calculator | GCP Pricing Calculator | Azure Pricing Calculator |
 |  |  |  | Azure Pricing Calculator |
-| Billing and Reporting | Google Cloud Billing Reports | AWS Cost Explorer | Azure Cost Management + Billing |
+| *Billing and Reporting* | Google Cloud Billing Reports | AWS Cost Explorer | Azure Cost Management + Billing |
 |  | Billing Export (BigQuery) | AWS Cost and Usage Reports | Azure usage and charges report |
 |  | Pricing Export (BigQuery) | AWS Detailed Billing Reports |  |
 |  |  | AWS Purchase Order Management |  |
 |  |  | AWS Consolidated Billing |  |
 |  |  | AWS Credits |  |
-| Detailed Billing Analysis | Datastudio (BigQuery and BI Engine) | AWS Quick Sight | Azure Power BI |
+| *Detailed Billing Analysis* | Datastudio (BigQuery and BI Engine) | AWS Quick Sight | Azure Power BI |
 |  | Looker Analytics Dashboard |  |  |
-| Invoicing | Cost Table | AWS Invoices | Azure Invoices |
+| *Invoicing* | Cost Table | AWS Invoices | Azure Invoices |
 |  | Cost breakdown |  |  |
-| Forecasting | Billing Forecast |  |  |
-| Tagging | Resource Hierarchy | AWS Tag Editor | Azure Policy |
-| Alerts and Notications | Budget Alerts | AWS Budgets | Azure Budgets |
-| Template Driven Deployment | Terraform | AWS Cloud Formation | Azure Resource Manager |
-| Controls | Quotas and Rate Limit APIs | Service Limits |  |
+| *Forecasting* | Billing Forecast |  |  |
+| *Tagging* | Resource Hierarchy | AWS Tag Editor | Azure Policy |
+| *Alerts and Notications* | Budget Alerts | AWS Budgets | Azure Budgets |
+| *Template Driven Deployment* | Terraform | AWS Cloud Formation | Azure Resource Manager |
+| *Controls* | Quotas and Rate Limit APIs | Service Limits |  |
 |  |  | AWS Instance Scheduler |  |
 |  |  | Amazon Data Lifecycle Manager |  |
-| Recommendations | Recommender | AWS Cost Explorer | Azure Advisor |
+| *Recommendations* | Recommender | AWS Cost Explorer | Azure Advisor |
 |  | Active Assist | Trusted Advisor | Azure Monitor |
 |  | Google Cloud's operations suite (formerly Stackdriver) |  |  |
 |  | Commitment Analysis |  |  |
-| Insights | Billing Health Checks | CloudWatch |  |
+| *Insights* | Billing Health Checks | CloudWatch |  |
 |  |  | CloudTrail |  |
 |  |  |  |  |
 

--- a/projects/multi-cloud-tools-and-terminology.md
+++ b/projects/multi-cloud-tools-and-terminology.md
@@ -35,30 +35,30 @@ Each Cloud Service Provider has different tools available to help FinOps practit
 
 |  | GCP        | AWS           | Azure  |
 | ------------- | ------------- | ------------- | ------------- |
-| *Cloud Cost Planning* | GCP Pricing Calculator | GCP Pricing Calculator | Azure Pricing Calculator |
+| **Cloud Cost Planning** | GCP Pricing Calculator | GCP Pricing Calculator | Azure Pricing Calculator |
 |  |  |  | Azure Pricing Calculator |
-| *Billing and Reporting* | Google Cloud Billing Reports | AWS Cost Explorer | Azure Cost Management + Billing |
+| **Billing and Reporting** | Google Cloud Billing Reports | AWS Cost Explorer | Azure Cost Management + Billing |
 |  | Billing Export (BigQuery) | AWS Cost and Usage Reports | Azure usage and charges report |
 |  | Pricing Export (BigQuery) | AWS Detailed Billing Reports |  |
 |  |  | AWS Purchase Order Management |  |
 |  |  | AWS Consolidated Billing |  |
 |  |  | AWS Credits |  |
-| *Detailed Billing Analysis* | Datastudio (BigQuery and BI Engine) | AWS Quick Sight | Azure Power BI |
+| **Detailed Billing Analysis** | Datastudio (BigQuery and BI Engine) | AWS Quick Sight | Azure Power BI |
 |  | Looker Analytics Dashboard |  |  |
-| *Invoicing* | Cost Table | AWS Invoices | Azure Invoices |
+| **Invoicing** | Cost Table | AWS Invoices | Azure Invoices |
 |  | Cost breakdown |  |  |
-| *Forecasting* | Billing Forecast |  |  |
-| *Tagging* | Resource Hierarchy | AWS Tag Editor | Azure Policy |
-| *Alerts and Notications* | Budget Alerts | AWS Budgets | Azure Budgets |
-| *Template Driven Deployment* | Terraform | AWS Cloud Formation | Azure Resource Manager |
-| *Controls* | Quotas and Rate Limit APIs | Service Limits |  |
+| **Forecasting** | Billing Forecast |  |  |
+| **Tagging** | Resource Hierarchy | AWS Tag Editor | Azure Policy |
+| **Alerts and Notications** | Budget Alerts | AWS Budgets | Azure Budgets |
+| **Template Driven Deployment** | Terraform | AWS Cloud Formation | Azure Resource Manager |
+| **Controls** | Quotas and Rate Limit APIs | Service Limits |  |
 |  |  | AWS Instance Scheduler |  |
 |  |  | Amazon Data Lifecycle Manager |  |
-| *Recommendations* | Recommender | AWS Cost Explorer | Azure Advisor |
+| **Recommendations** | Recommender | AWS Cost Explorer | Azure Advisor |
 |  | Active Assist | Trusted Advisor | Azure Monitor |
 |  | Google Cloud's operations suite (formerly Stackdriver) |  |  |
 |  | Commitment Analysis |  |  |
-| *Insights* | Billing Health Checks | CloudWatch |  |
+| **Insights** | Billing Health Checks | CloudWatch |  |
 |  |  | CloudTrail |  |
 |  |  |  |  |
 

--- a/projects/multi-cloud-tools-and-terminology.md
+++ b/projects/multi-cloud-tools-and-terminology.md
@@ -39,11 +39,7 @@ Each Cloud Service Provider has different tools available to help FinOps practit
 
 
 ## Cost Management Terminology
-Cloud Service Providers utilize different terms to mean the same or similar things.  This can make understanding cloud concepts across providers difficult.  The Cost Management Terminology Across CSPs tools was  created to help FinOps practitioners translate these common terms across Cloud Service Providers.  
-
-| _Coming Soon..._ |
-|---|
-| _Cost Management Terminology Across CSPs_ |
+Cloud Service Providers utilize different terms to mean the same or similar things.  This can make understanding cloud concepts across providers difficult.  This terminology generated from this project was created to help FinOps practitioners translate these common terms across Cloud Service Providers and has been incorporated into [the FinOps Terminology page here](https://www.finops.org/resources/terminology/).
 
 
 #### Three Letter Acronyms

--- a/projects/multi-cloud-tools-and-terminology.md
+++ b/projects/multi-cloud-tools-and-terminology.md
@@ -33,9 +33,35 @@ If you have a strong handle on these subjects, please continue on to better unde
 ## FinOps Tools Matrix
 Each Cloud Service Provider has different tools available to help FinOps practitioners learn and practice efficient utilization of cloud resources.  There are tools and reports available that can help FinOps practitioners and companies plan their potential cost in advance of consumption, understand invoices, complete billing analysis, govern cost and optimize cost.  These tools have been enumerated in the FinOps Tools Matrix.
 
-| _Coming Soon..._ |
-|---|
-| _FinOps Tools Matrix info_ |
+|  | GCP        | AWS           | Azure  |
+| ------------- | ------------- | ------------- | ------------- |
+| Cloud Cost Planning | GCP Pricing Calculator | GCP Pricing Calculator | Azure Pricing Calculator |
+|  |  |  | Azure Pricing Calculator |
+| Billing and Reporting | Google Cloud Billing Reports | AWS Cost Explorer | Azure Cost Management + Billing |
+|  | Billing Export (BigQuery) | AWS Cost and Usage Reports | Azure usage and charges report |
+|  | Pricing Export (BigQuery) | AWS Detailed Billing Reports |  |
+|  |  | AWS Purchase Order Management |  |
+|  |  | AWS Consolidated Billing |  |
+|  |  | AWS Credits |  |
+| Detailed Billing Analysis | Datastudio (BigQuery and BI Engine) | AWS Quick Sight | Azure Power BI |
+|  | Looker Analytics Dashboard |  |  |
+| Invoicing | Cost Table | AWS Invoices | Azure Invoices |
+|  | Cost breakdown |  |  |
+| Forecasting | Billing Forecast |  |  |
+| Tagging | Resource Hierarchy | AWS Tag Editor | Azure Policy |
+| Alerts and Notications | Budget Alerts | AWS Budgets | Azure Budgets |
+| Template Driven Deployment | Terraform | AWS Cloud Formation | Azure Resource Manager |
+| Controls | Quotas and Rate Limit APIs | Service Limits |  |
+|  |  | AWS Instance Scheduler |  |
+|  |  | Amazon Data Lifecycle Manager |  |
+| Recommendations | Recommender | AWS Cost Explorer | Azure Advisor |
+|  | Active Assist | Trusted Advisor | Azure Monitor |
+|  | Google Cloud's operations suite (formerly Stackdriver) |  |  |
+|  | Commitment Analysis |  |  |
+| Insights | Billing Health Checks | CloudWatch |  |
+|  |  | CloudTrail |  |
+|  |  |  |  |
+
 
 
 ## Cost Management Terminology


### PR DESCRIPTION
update the multi-cloud WG project page to

- x-ref the new terminology from foundational work from the multi-cloud WG back to the FinOps Terminology page
- add the WG tools matrix to the project page

resolves #253 