### PR TITLE
[framework ] updates for framework capabilities content and metadata

### DIFF
--- a/_capabilities/analysis-showback.md
+++ b/_capabilities/analysis-showback.md
@@ -113,6 +113,6 @@ _Get involved and contribute to the community by sharing your real world experie
 * _the complexity of the organization (global enterprise, start-up, etc…)_
 * _the [FinOps personas](https://www.finops.org/framework/personas/) involved / organizational roles_
 
-_Join the conversation about this Capability in Slack <!-- [insert name and link to Slack channel here] -->. You can submit stories, how-tos and suggest improvements [using one of the options for contributing here](https://www.finops.org/introduction/how-to-contribute/)._
+_Join the conversation about this Capability in the Slack channel [#data-analysis-and-showback](https://finopsfoundation.slack.com/archives/C02QEAZLBLH). You can submit stories, how-tos and suggest improvements [using one of the options for contributing here](https://www.finops.org/introduction/how-to-contribute/)._
 
 ---

--- a/_capabilities/chargeback.md
+++ b/_capabilities/chargeback.md
@@ -3,11 +3,11 @@
 layout: wide
 
 title: Chargeback & IT Finance Integration
-description: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense. Once chargeback has been implemented and visibility given to teams, mature FinOps practitioners then integrate that data programmatically into their relevant internal reporting systems and financial management tools.
+description: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense.
 permalink: /framework/capabilities/chargeback/
 page-identifier: capability_chargeback
 framework-capability-title: Chargeback & IT Finance Integration
-framework-capability-desc: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense. Once chargeback has been implemented and visibility given to teams, mature FinOps practitioners then integrate that data programmatically into their relevant internal reporting systems and financial management tools.
+framework-capability-desc: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense.
 order: 12
 
 ---

--- a/_capabilities/chargeback.md
+++ b/_capabilities/chargeback.md
@@ -1,13 +1,13 @@
 ---
 
-layout: default
+layout: wide
 
 title: Chargeback & IT Finance Integration
-description: coming soon...
+description: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense. Once chargeback has been implemented and visibility given to teams, mature FinOps practitioners then integrate that data programmatically into their relevant internal reporting systems and financial management tools.
 permalink: /framework/capabilities/chargeback/
 page-identifier: capability_chargeback
 framework-capability-title: Chargeback & IT Finance Integration
-framework-capability-desc: coming soon...
+framework-capability-desc: Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense. Once chargeback has been implemented and visibility given to teams, mature FinOps practitioners then integrate that data programmatically into their relevant internal reporting systems and financial management tools.
 order: 12
 
 ---
@@ -21,17 +21,63 @@ order: 12
 
 
 ## Definition
-_definition for this Capability.  the objective here is to capture the "What" (**not** the "How") for this Capability._
+Chargeback and IT Finance Integration is about pushing spend accountability to the edges of the organization that are responsible for creating the expense.
+
+Once chargeback has been implemented and visibility given to teams, [mature FinOps practitioners](https://www.finops.org/framework/maturity-model/) then integrate that data programmatically into their relevant internal reporting systems and financial management tools.
+
+Chargeback is the focus in this capability, but [Showback](https://www.finops.org/framework/capabilities/analysis-showback/) is a foundational part of any FinOps practice.  The difference is that Chargeback sends expenses to a product or department P&L and Showback shows the charges by product or department but keeps the expenses in a centralized budget.  Neither way should be considered more mature than the other, as which method used is entirely dependent on organizational accounting policy and preference.
+
+A tagging and account strategy is vital as ways to identify costs.  By either assigning a tag to a resource, or by designating a cost center that pays for resources in a certain account, practitioners can identify who is accountable for the expense incurred.
+
+Another consideration in this capability is how to allocate [shared organizational costs](https://www.finops.org/framework/capabilities/manage-shared-cloud-cost/) and [commitment based discounts](https://www.finops.org/framework/capabilities/manage-commitment-based-discounts/).  Will these be held centrally or allocated based on consumption?  
+
+It is important for a centralized FinOps team to align with their finance partners to make sure that the decisions made in this capability (chargeback vs showback, tagging and accounting strategies, how to handle shared costs) can integrate with the companies IT policies and systems.  The goal is to make it easy for users to be accountable for their expenses. The best way to do this is by integrating with the company's finance tools and processes.
+
 
 
 ## Maturity Assessment
-_description of the characteristics of each maturity level (crawl, walk, run) for this Capability in the context of the organization's FinOps practice._
+
+#### Crawl
+* Cloud spend is allocated to teams based on estimated usage of resources.
+* Shared costs and discounts are held centrally due to lack of strategy on how to provide visibility and/or allocation.
+
+#### Walk
+* Tagging strategy and/or Account strategy is in place to provide visibility into how expense is allocated
+* Strategy implemented on how to show and allocate shared costs/discounts
+
+#### Run
+* Teams understand their direct and allocated shared cost portion of cloud spend based on their actual consumption.
+* Chargeback/Showback reporting is integrated automatically into the companies IT finance tooling
+
 
 
 
 ## Functional Activity
-_written for each persona responsible for the functional activity and processes encapsulated by his Capability.  each one should be associated generally to one of the FinOps Phases (Inform, Optimize, Operate). for example:_
->As a [FinOps Persona], I will [functional activity] so that [desired outcome] is achieved.
+
+#### As someone in a Business/Product role, I will…
+* Review the costs I am accountable for each month
+* Understand how these costs impact my budget
+* Have an understanding of organizational policy regarding chargeback/showback and allocation of shared costs/discounts
+
+
+#### As someone in a Finance/FinOps role, I will…
+* Understand how cloud expense is generated
+* Ensure there is appropriate documentation on chargeback/showback policy and that operations are auditable according to company policies
+* Help teams reconcile their portion of expense that is allocated to them each month
+* Help teach teams the tagging and account policies and the importance of expense accountability
+
+
+#### As someone in an Engineering/Operations role, I will...
+* Understand how cloud expense is generated for each service used
+* Comply with company tagging and account policies
+* Review costs incurred each month
+
+
+#### As someone in an Executive role, I will…
+* Understand how cloud expense is generated
+* Review cloud expense for portions they are accountable for
+* Leverage this information for real time decision making
+
 
 
 
@@ -44,7 +90,10 @@ _for example:_
 
 
 ## Inputs
-_the information used that contributes to the measure(s) of success listed above; information here may include specific datasources, reports or any relevant input_
+* Tagging and Account strategy are important for cost allocation.
+* Company accounting policy
+* Company cost center/department hierarchy
+
 
 
 <!-- ####### Real World Resources ####### -->
@@ -80,6 +129,6 @@ _Get involved and contribute to the community by sharing your real world experie
 * _the complexity of the organization (global enterprise, start-up, etc…)_
 * _the [FinOps personas](https://www.finops.org/framework/personas/) involved / organizational roles_
 
-_Join the conversation about this Capability in Slack <!-- [insert name and link to Slack channel here] -->. You can submit stories, how-tos and suggest improvements [using one of the options for contributing here](https://www.finops.org/introduction/how-to-contribute/)._
+_Join the conversation about this Capability in the Slack channel [#chargeback-and-it_finance-integration](https://finopsfoundation.slack.com/archives/C02Q0J0G4P5). You can submit stories, how-tos and suggest improvements [using one of the options for contributing here](https://www.finops.org/introduction/how-to-contribute/)._
 
 ---

--- a/_capabilities/forecasting.md
+++ b/_capabilities/forecasting.md
@@ -14,7 +14,10 @@ order: 5
 
 # Forecasting
 
+{% include contribute-capabiility.md %}
+
 {% include domains-loop.md %}
+
 
 ## Definition
 Forecasting is the practice of predicting future spending, usually based on a combination of historical spending and an evaluation of future plans, understanding how future cloud infrastructure and application lifecycle changes may impact current budgets and influence budget planning and future cloud investment decisions.

--- a/_capabilities/manage-shared-cloud-costs.md
+++ b/_capabilities/manage-shared-cloud-costs.md
@@ -20,7 +20,7 @@ order: 4
 
 
 ## Definition
-A foundational principle of FinOps is: "Everyone takes ownership for their cloud usage".  The true key to understanding total cost of ownership is built upon transparency and accuracy, but unallocated shared costs hinders both of these. Without appropriately splitting costs that are shared, engineers and product managers lack a complete picture of how much their products are really costing.
+A foundational [Principle of FinOps](https://www.finops.org/framework/principles/) is: "Everyone takes ownership for their cloud usage".  The true key to understanding total cost of ownership is built upon transparency and accuracy, but unallocated shared costs hinders both of these. Without appropriately splitting costs that are shared, engineers and product managers lack a complete picture of how much their products are really costing.
 
 The goal of Cost Sharing is can be full allocation; however it can also be the adoption of an informed ignore approach.  The latter is where a business decision is explicitly made about shared platform services coming from a central budget versus a from a portion of each cost center's budget.
 
@@ -58,6 +58,7 @@ As organizations increase their adoption of public cloud, without a strategy and
 
 
 ## Functional Activity
+
 #### As someone in a Business/Product role, I will…
 * identify shared services/infrastructure which are part of my product and engage with stakeholder FinOps personas to determine how to
 * understand cloud providers common use cases, and have a basic understanding of billing and pricing models


### PR DESCRIPTION
ø updated url in manage-shared-cost capability to link back to finops principles
ø added contribute cta banner to top-of-page for manage-shared-cost capability
o added foundational content for chargeback-and-it-finance-integration capability
ø added url for slack channel to the data-analysis-and-showback capability
ø resolves #280 