### PR TITLE
Fix so that stories use desc instead of body content

### DIFF
--- a/_includes/story-loop.md
+++ b/_includes/story-loop.md
@@ -58,7 +58,8 @@
   </div>
   <em>{% if story.author %} by {{ story.author | join: " and " }}{% else %} by a Foundation Member{% endif %}{% if story.company %}, {{ story.company }}{% endif %}</em>
   <div>
-    {{ story.content | truncatewords: 50 | markdownify}} <a class="text-green-500 text-sm" href="{{ story.url }}">Read more</a>
+    {% if story.description %} {{ story.description | truncatewords: 50 | markdownify}} {% else %} {{ story.content | truncatewords: 50 | markdownify}} {% endif %} <a class="text-green-500 text-sm" href="{{ story.url }}">Read more</a>
+    <!-- {{ story.content | truncatewords: 50 | markdownify}} <a class="text-green-500 text-sm" href="{{ story.url }}">Read more</a> -->
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
Some stories don't render properly on projects because the story loop doesn't include descriptions. This PR attempts to remedy that.