### PR TITLE
[partner-members] updated metadata to fix certification categorization

### DIFF
--- a/_tools-services/kubecost.md
+++ b/_tools-services/kubecost.md
@@ -15,13 +15,14 @@ company-description: Kubecost is the leading open source Kubernetes cloud cost m
 member-level: premier
 member-order: 16
 
-type: 
-- Service Provider
+type:
+- Platform Provider
 
 certified-status:
-- FinOps Certified Platform
+#- FinOps Certified Platform
+- FinOps Certified Solution
 
-# Product(s) or service overview maximum character count is 1000 the rest will be truncated and hidden automatically on your page 
+# Product(s) or service overview maximum character count is 1000 the rest will be truncated and hidden automatically on your page
 product-overview: Kubecost is the easiest way for engineers to manage cloud costs, empowering teams to monitor and optimize their Kubernetes environment. Available as open source (Apache v2), it can be installed with a helm command in less than 5 minutes on any Kubernetes cluster. It provides a comprehensive view of all in-cluster and out-of-cluster cloud spend, enabling accurate showbacks, chargebacks, monitoring, and alerting. With AWS, Azure, and GCP billing integrations, Kubecost gives teams full visibility into the cost and efficiency of their modern multi-cloud infrastructure. We support on-premise and air-gapped environments for teams operating within the strictest security requirements and data export regulations. Our customer-favorite rightsizing recommendations provide customized guidance based on the user's environment and behavior patterns. With Enterprise, users get additional support for multi-cluster, SSO/SAML, unlimited data retention, added alerting capabilities, and dedicated support.
 
 product-video-url: "https://www.youtube.com/embed/OGwb_-Nkfek"
@@ -58,7 +59,7 @@ clouds-supported:
 - Data Center
 - Private Cloud
 
-# FinOps Foundation Member since 
+# FinOps Foundation Member since
 date: 2020-08-01
 
 # Show recent related FinOps activity, it can be content, webinars, thought leadership and include external links
@@ -72,7 +73,7 @@ slack:
   url:
 
 # The total number of FinOps Certified Practitioners at the vendor
-number-of-focp: 
+number-of-focp:
 
 # List the key contribution areas in the FinOps Foundation, examples listed
 contribution-areas:

--- a/_tools-services/prosperops.md
+++ b/_tools-services/prosperops.md
@@ -12,18 +12,19 @@ website-url: "https://www.prosperops.com/"
 # Maximum character count is 350 the rest will be truncated and hidden automatically on your page
 company-description: "ProsperOps delivers a fully autonomous cost optimization service for AWS that maximizes your savings and minimizes commitment risk with zero ongoing effort. You automatically achieve effective saving rates of 40+% (placing you in the 99th percentile of optimizers) with commitments that dynamically adapt to usage changes in real-time."
 
-# Membership level, type and vendor certifications 
+# Membership level, type and vendor certifications
 member-level: general
 
-type: 
+type:
 - Platform Provider
- 
+
 certified-status:
 #- FinOps Certified Service Provider
 #- FinOps Certified Platform
+#- FinOps Certified Solution
 #- FinOps Training Partner
 
-# Product(s) or service overview maximum character count is 1000 the rest will be truncated and hidden automatically on your page 
+# Product(s) or service overview maximum character count is 1000 the rest will be truncated and hidden automatically on your page
 product-overview: |
   AWS tends to be one of the largest line items in a company's cost structure and compute typically makes up 60% of the bill. AWS provides multiple financial tools to reduce spend, but each approach has different trade-offs. Companies either undersave, leaving money on the table, or take too much risk, and end up overcommitted.
 
@@ -31,13 +32,13 @@ product-overview: |
 
 product-video-url: "https://player.vimeo.com/video/604233506?h=dfce9f8f8a&color=5c54ff&title=0&byline=0&portrait=0"
 
-# Related product or service resources, the titles will have associated URLs, e.g. product 
+# Related product or service resources, the titles will have associated URLs, e.g. product
 product-resources:
 - title: FinOps Testimonial
   url: "https://vimeo.com/583555044"
 - title: DevOps Testimonial
   url: "https://vimeo.com/589967367"
-- title: ProsperOps Console Overview 
+- title: ProsperOps Console Overview
   url: "https://vimeo.com/590006262"
 
 # Supported capabilities in the framework by the product(s) or services. Match the page-identifier per capability in order for the capability to show up on the vendor page.
@@ -53,7 +54,7 @@ capabilities:
 clouds-supported:
 - AWS
 
-# FinOps Foundation Member since 
+# FinOps Foundation Member since
 date: 2020-08-01
 
 # Show recent related FinOps activity, it can be content, webinars, thought leadership and include external links
@@ -65,7 +66,7 @@ recent-finops-activity:
 - title: Supercharging AWS Savings Plans
   url: "https://vimeo.com/590006339"
 
-# Detail related/dedicated slack channels in the FinOps Foundation Slack 
+# Detail related/dedicated slack channels in the FinOps Foundation Slack
 slack-channels:
 - title: prosperops
   url: https://finopsfoundation.slack.com/archives/C019HF7QWQZ
@@ -77,6 +78,6 @@ number-of-focp: 3
 contribution-areas:
 - Technical Advisory Council
 - Capabilities SIG
-- Active Slack Member 
+- Active Slack Member
 
 ---


### PR DESCRIPTION
with it's specialized focus on K8s cost management, kubecost should have been categorized as FCS (not FCP)